### PR TITLE
Fix Regex.Match in IsPhoneNumber(string number)

### DIFF
--- a/AfricasTalkingCS/AfricasTalkingGateway.cs
+++ b/AfricasTalkingCS/AfricasTalkingGateway.cs
@@ -182,7 +182,7 @@ namespace AfricasTalkingCS
         /// </returns>
         private static bool IsPhoneNumber(string number)
         {
-            return Regex.Match(number, @"^\+?(\d[\d-. ]+)?(\([\d-. ]+\))?[\d-. ]+\d$").Success && number.Length > 5;
+            return Regex.Match(number, @"^\+?(\d[\d-. +,]+)?(\([\d-. +,]+\))?[\d-. ]+\d$").Success && number.Length > 5;
         }
 
         /// <summary>


### PR DESCRIPTION
line: 185 Update to IsPhoneNumber(string number) Regex.Match to accept comma separated numbers
+254708440184                                                         :true
+254708440184,+254708440184,+254708440184   :true
+254708440184,                                                        :false
+254708440184,+254708440184,+254708440184,   :false