### PR TITLE
netcoreapp  to  netstandard

### DIFF
--- a/AfricasTalkingCS.Tests/AfricasTalkingCS.Tests.csproj
+++ b/AfricasTalkingCS.Tests/AfricasTalkingCS.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>netstandard2.0</TargetFramework>
-
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/AfricasTalkingCS.Tests/AfricasTalkingCS.Tests.csproj
+++ b/AfricasTalkingCS.Tests/AfricasTalkingCS.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/AfricasTalkingCS.Tests/AfricasTalkingCS.Tests.csproj
+++ b/AfricasTalkingCS.Tests/AfricasTalkingCS.Tests.csproj
@@ -1,15 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AfricasTalkingCS/AfricasTalkingCS.csproj
+++ b/AfricasTalkingCS/AfricasTalkingCS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;net48;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.2.3</Version>
@@ -33,10 +33,10 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="libphonenumber-csharp" Version="8.12.11" />
-    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+    <PackageReference Include="libphonenumber-csharp" Version="8.13.10" />
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   

--- a/Examples/AirtimeSample/AirtimeSample.csproj
+++ b/Examples/AirtimeSample/AirtimeSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/BankCheckout/BankCheckout.csproj
+++ b/Examples/BankCheckout/BankCheckout.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/BankTransfer/BankTransfer.csproj
+++ b/Examples/BankTransfer/BankTransfer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/ConsoleApp1/SampleSMSApp.csproj
+++ b/Examples/ConsoleApp1/SampleSMSApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/ConsoleApp2/SampleC2BApp.csproj
+++ b/Examples/ConsoleApp2/SampleC2BApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/CreateSubscription/CreateSubscription.csproj
+++ b/Examples/CreateSubscription/CreateSubscription.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/CreateToken/CreateToken.csproj
+++ b/Examples/CreateToken/CreateToken.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/FetchMessages/FetchMessages.csproj
+++ b/Examples/FetchMessages/FetchMessages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/GetUser Balance/GetUser Balance.csproj
+++ b/Examples/GetUser Balance/GetUser Balance.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/OTPCardValidation/OTPCardValidation.csproj
+++ b/Examples/OTPCardValidation/OTPCardValidation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/SampleB2C/SampleB2C.csproj
+++ b/Examples/SampleB2C/SampleB2C.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/SampleBulkSms/SampleBulkSms.csproj
+++ b/Examples/SampleBulkSms/SampleBulkSms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
     <ItemGroup>

--- a/Examples/SandboxDefaultEnv/SandboxDefaultEnv.csproj
+++ b/Examples/SandboxDefaultEnv/SandboxDefaultEnv.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/SendPremiumSMS/SendPremiumSMS.csproj
+++ b/Examples/SendPremiumSMS/SendPremiumSMS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
     <StartupObject>SendPremiumSMS.Program</StartupObject>
   </PropertyGroup>
 

--- a/Examples/USSDPushSample/USSDPushSample.csproj
+++ b/Examples/USSDPushSample/USSDPushSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/ValidateCardOTPOnly/ValidateCardOTPOnly.csproj
+++ b/Examples/ValidateCardOTPOnly/ValidateCardOTPOnly.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Examples/Voice.MakeCall/Voice.MakeCall.csproj
+++ b/Examples/Voice.MakeCall/Voice.MakeCall.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+	  <TargetFramework>netstandard2.0</TargetFramework>
     <StartupObject>Voice.MakeCall.Program</StartupObject>
   </PropertyGroup>
 


### PR DESCRIPTION
When a library is built against a certain version of .NET Standard, it can run on any .NET implementation that implements that version of .NET Standard (or higher).

Targeting a higher version of .NET Standard allows a library to use more APIs but means it can only be used on more recent versions of .NET. Targeting a lower version reduces the available APIs but means the library can run in more places.

[.NET Implementation] (https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0)